### PR TITLE
Add datadog tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,15 @@ matrix:
   fast_finish: true
   include:
     - python: 2.6
-      env: MONGODB=3.4.2
+      env: MONGODB=3.4.2 DATADOG_API_KEY='' DATADOG_APP_KEY=''
     - python: 2.7
-      env: MONGODB=3.2.12
+      env: MONGODB=3.2.12 DATADOG_API_KEY='' DATADOG_APP_KEY=''
     - python: 3.3
-      env: MONGODB=3.0.14
+      env: MONGODB=3.0.14 DATADOG_API_KEY='' DATADOG_APP_KEY=''
     - python: 3.4
-      env: MONGODB=2.6.12
+      env: MONGODB=2.6.12 DATADOG_API_KEY='' DATADOG_APP_KEY=''
     - python: 3.5
-      env: MONGODB=2.4.14
+      env: MONGODB=2.4.14 DATADOG_API_KEY='' DATADOG_APP_KEY=''
 
 install:
   - pip install "mongo-orchestration>=0.6.7,<1.0"

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(name='mongo-connector',
       license="http://www.apache.org/licenses/LICENSE-2.0.html",
       platforms=["any"],
       classifiers=filter(None, classifiers.split("\n")),
-      install_requires=['pymongo >= 2.9'],
+      install_requires=['pymongo >= 2.9', 'datadog >= = 0.15'],
       packages=["mongo_connector", "mongo_connector.doc_managers"],
       package_data={
           'mongo_connector.doc_managers': ['schema.xml']

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(name='mongo-connector',
       license="http://www.apache.org/licenses/LICENSE-2.0.html",
       platforms=["any"],
       classifiers=filter(None, classifiers.split("\n")),
-      install_requires=['pymongo >= 2.9', 'datadog >= = 0.15'],
+      install_requires=['pymongo >= 2.9', 'datadog >= 0.15'],
       packages=["mongo_connector", "mongo_connector.doc_managers"],
       package_data={
           'mongo_connector.doc_managers': ['schema.xml']


### PR DESCRIPTION
hey @stevenc81 @kiriappeee , added the lag tracking for datadog.
We will see the metrics it in datadog under the name `mongo_connector.lag.REPLICASET`
We would need to set the APP and API keys before running the mongo-connector.